### PR TITLE
Fix player freeze glitchiness.

### DIFF
--- a/src/main/java/net/SimpleSurvival/GameManager.java
+++ b/src/main/java/net/SimpleSurvival/GameManager.java
@@ -75,7 +75,9 @@ class GameEvents implements Listener {
             if (currentGame.getState() == GameSettings.GameState.PAUSED) {
                 Vector to = event.getTo().toVector();
                 Vector from = event.getFrom().toVector();
+                Player player = event.getPlayer();
                 if (to.getX() != from.getX() || to.getZ() != from.getZ()) {
+                    player.teleport(event.getFrom());
                     event.setCancelled(true);
                 }
             }


### PR DESCRIPTION
Only cancel move events if they are translations along the x or z axes.
Ignore any vertical movement (in case the players are spawned in the
air) or any rotational movement.
